### PR TITLE
add context propagation to loading cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+traces/*.txt

--- a/cache.go
+++ b/cache.go
@@ -2,6 +2,8 @@
 // including support for LRU, Segmented LRU and TinyLFU.
 package cache
 
+import "context"
+
 // Key is any value which is comparable.
 // See http://golang.org/ref/spec#Comparison_operators for details.
 type Key interface{}
@@ -45,7 +47,14 @@ type LoadingCache interface {
 	// Get returns value associated with Key or call underlying LoaderFunc
 	// to load value if it is not present.
 	Get(Key) (Value, error)
+
+	// GetContext returns value associated with Key or call underlying LoaderFunc
+	// to load value if it is not present.
+	GetContext(context.Context, Key) (Value, error)
 }
 
 // LoaderFunc retrieves the value corresponding to given Key.
 type LoaderFunc func(Key) (Value, error)
+
+// LoaderFuncContext retrieves the value corresponding to given Key.
+type LoaderFuncContext func(context.Context, Key) (Value, error)


### PR DESCRIPTION
I'd like to change our internal dependency on `goburrow/cache` to `lightstep/cache` directly.

This will remove the need to alias our dependency in lightstep/lightstep's Gopkg files. This will also make migration to `go mod` in the future simpler. I discovered this issue when doing a trial migration to `go mod` to see what issues there might be.

In order to depend on `lightstep/cache` I'd like to merge this branch to master. @MatthewDolan what do you think about that change?