### PR TITLE
local: introduce jittered TTL

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -16,7 +16,7 @@ func main() {
 	c := cache.NewLoadingCache(load,
 		cache.WithMaximumSize(1000),
 		cache.WithExpireAfterAccess(10*time.Second),
-		cache.WithRefreshAfterWrite(60*time.Second),
+		cache.WithExpireAfterWrite(60*time.Second),
 	)
 
 	getTicker := time.Tick(10 * time.Millisecond)

--- a/policy.go
+++ b/policy.go
@@ -11,10 +11,24 @@ type entry struct {
 	key   Key
 	value Value
 
-	// accessed is the last time this entry was accessed.
-	accessed time.Time
-	// updated is the last time this entry was updated.
-	updated time.Time
+	// expireAfterAccessDeadline is the
+	// time that this entry should be removed, due
+	// to the ExpireAfterAccess config.
+	// This will be updated each time the entry is
+	// accessed.
+	// This is not jittered as the entries list is
+	// ordered by this.
+	expireAfterAccessDeadline time.Time
+
+	// expireAfterWriteDeadline is the
+	// time that this entry should be removed, due
+	// to the ExpireAfterWrite config.
+	// This will be updated each time the entry is
+	// accessed.
+	// It may be jittered, so the time may not align
+	// exactly with ExpireAfterWrite.
+	expireAfterWriteDeadline time.Time
+
 	// listID is ID of the list which this entry is currently in.
 	listID listID
 	// hash is the hash value of this entry key


### PR DESCRIPTION
Jitter the result of WithExpireAfterWrite, but not
WithExpireAfterAccess. We cannot naively jitter the result of
WithExpireAfterAccess because an internal list is ordered by last access
time (in the case of this PR, by expiry time).

WithRefreshAfterWrite appears to not have any effect in upstream anymore, so remove the option.